### PR TITLE
Added python version of XY translation analysis

### DIFF
--- a/code/Cross_correlation_graphs.py
+++ b/code/Cross_correlation_graphs.py
@@ -1,0 +1,93 @@
+# import the necessary packages
+import os
+from os.path import dirname
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+from tkinter import Tk
+from tkinter.filedialog import askopenfilename  # User input interface
+
+# to use this script on its own give the path of coordinates file
+# Get main path
+outer_dir = dirname(os.getcwd())
+# Ask user the path to coordinates file :
+root = Tk()
+root.attributes("-topmost", True)
+root.withdraw()
+coord_path = askopenfilename(initialdir=outer_dir, title='Select coordinate file to analyse')
+coord = pd.read_csv(coord_path, encoding='utf-8-sig')
+
+
+# Create graphs
+plot_coord = coord.dropna(subset=['Direction'])
+# Plot graphs of recorded vs expected X and Y in each direction
+plot_coord = plot_coord[(coord['Direction'] != 'Zero') &
+                        (coord['Direction'] != 'Z_positive') &
+                        (coord['Direction'] != 'Z_negative')]
+plot_coord = plot_coord[(plot_coord['theoretical_distance'] < 300) & (plot_coord['theoretical_distance'] > -300)]
+
+# Plot X results
+plot_x = sns.lmplot(x="theoretical_distance", y="Crosscor_tx_microm", hue="Direction", data=plot_coord,
+                    height=6, aspect=1, ci=False)
+plot_x.fig.suptitle("X DISPLACEMENT", fontsize=12)
+plot_x.set(xlabel="Theoretical movement (µm)",
+           ylabel="Recorded X movement (µm)",
+           xlim=(-130, 130),
+           ylim=(-130, 130))
+plt.axvline(0, ymin=0.1, ymax=0.9, color="black", linestyle="--")
+plt.axhline(0, xmin=0.1, xmax=0.9, color="black", linestyle="--")
+plt.show()
+plt.savefig(dirname(coord_path)+"/X_translation_error.png")
+
+# Plot Y results
+plot_y = sns.lmplot(x="theoretical_distance", y="Crosscor_ty_microm", hue="Direction", data=plot_coord,
+                    height=6, aspect=1, ci=False)
+plot_y.fig.suptitle("Y DISPLACEMENT", fontsize=12)
+plot_y.set(xlabel="Theoretical movement (µm)",
+           ylabel="Recorded Y movement (µm)",
+           xlim=(-130, 130),
+           ylim=(-130, 130))
+plt.axvline(0, ymin=0.1, ymax=0.9, color="black", linestyle="--")
+plt.axhline(0, xmin=0.1, xmax=0.9, color="black", linestyle="--")
+plt.show()
+plt.savefig(dirname(coord_path)+"/Y_translation_error.png")
+
+# Plot returning to Zero error
+plot_coord_0 = coord.dropna(subset=['Direction'])
+plot_coord_0 = plot_coord_0[(plot_coord_0['Direction'] != 'Z_positive') &
+                            (plot_coord_0['Direction'] != 'Z_negative')]
+plot_coord_0 = plot_coord_0.reset_index()
+plot_coord_0 = plot_coord_0[(plot_coord_0.theoretical_distance > 0).idxmax():]
+plot_coord_0.loc[:, 'Previous_distance'] = plot_coord_0.theoretical_distance.shift(1)
+plot_coord_0.loc[:, 'Previous_direction'] = plot_coord_0.Direction.shift(1)
+plot_coord_0 = plot_coord_0[plot_coord_0['theoretical_distance'] == 0]
+# print(plot_coord_0.to_string())
+
+# Set figure grid
+fig, (ax1, ax2) = plt.subplots(ncols=2, sharey=True, figsize=(12, 6))
+# Plot X results
+sns.scatterplot(x='Previous_distance',
+                y='Crosscor_tx_microm',
+                hue='Previous_direction',
+                data=plot_coord_0,
+                ax=ax1)
+ax1.set(title='Error in X at Zero location',
+        xlabel='Previous theoretical movement (µm)',
+        ylabel='Recorded X movement (µm)')
+ax1.get_legend().remove()
+ax1.axvline(0, ymin=0.1, ymax=0.9, color="black", linestyle="--")
+ax1.axhline(0, xmin=0.1, xmax=0.9, color="black", linestyle="--")
+# Plot Y results
+sns.scatterplot(x="Previous_distance",
+                y="Crosscor_ty_microm",
+                hue="Previous_direction",
+                data=plot_coord_0,
+                ax=ax2)
+ax2.set(title='Error in Y at Zero location',
+        xlabel='Previous theoretical movement (µm)',
+        ylabel='Recorded Y movement (µm)')
+sns.move_legend(ax2, "upper left", bbox_to_anchor=(0.5, 1))
+ax2.axvline(0, ymin=0.1, ymax=0.9, color="black", linestyle="--")
+ax2.axhline(0, xmin=0.1, xmax=0.9, color="black", linestyle="--")
+plt.show()
+plt.savefig(dirname(coord_path)+"/Zero_translation_error.png")

--- a/code/Registration_cross_correlation.py
+++ b/code/Registration_cross_correlation.py
@@ -1,0 +1,138 @@
+# import the necessary packages
+import matplotlib.pyplot as plt
+import numpy as np
+import cv2
+# Import the scikit-image package https://scikit-image.org/
+# which allows loading stacks into numpy 3D arrays and use cross correlation to register images
+import skimage as ski
+from skimage.registration import phase_cross_correlation
+
+
+# Compute a rigid transformation (without depth, only translation)
+# Gives a shift (tx, ty)
+
+def cross_correlation_xy(translated_index, coord, px_size):
+    before_index = translated_index - 1
+    after_index = translated_index + 1
+    print(before_index, translated_index, after_index)
+
+    before_path = coord.Image_path.values[before_index]
+    translation_path = coord.Image_path.values[translated_index]
+    after_path = coord.Image_path.values[after_index]
+
+    before_image = cv2.imread(before_path)
+    translation_image = cv2.imread(translation_path)
+    after_image = cv2.imread(after_path)
+
+    before_image = cv2.cvtColor(before_image, cv2.COLOR_BGR2GRAY)
+    translation_image = cv2.cvtColor(translation_image, cv2.COLOR_BGR2GRAY)
+    after_image = cv2.cvtColor(after_image, cv2.COLOR_BGR2GRAY)
+
+    height, width = before_image.shape
+
+    # Calculate cross correlation and extract shift values
+    shift_bt, error, diffphase = phase_cross_correlation(before_image, translation_image, upsample_factor=100)
+    shift_ba, error_0, diffphase_0 = phase_cross_correlation(before_image, after_image, upsample_factor=100)
+
+    tx_bt = shift_bt[1]
+    ty_bt = shift_bt[0]
+    tx_ba = shift_ba[1]
+    ty_ba = shift_ba[0]
+
+    # Compute a euclidian transformation matrix
+    transformation_matrix_bt = np.array([[1, -0, tx_bt], [0, 1, ty_bt]])
+    transformation_matrix_ba = np.array([[1, -0, tx_ba], [0, 1, ty_ba]])
+
+    # Apply transformation to images
+    transformed_img_bt = cv2.warpAffine(translation_image, transformation_matrix_bt, (width, height),
+                                        borderValue=(150, 0, 0)
+                                        )
+    transformed_img_ba = cv2.warpAffine(after_image, transformation_matrix_ba, (width, height),
+                                        borderValue=(150, 0, 0)
+                                        )
+
+    # Save the output.
+    # Convert back to a 16bits image
+    transformed_img_bt = ski.util.img_as_uint(transformed_img_bt)
+    transformed_img_ba = ski.util.img_as_uint(transformed_img_ba)
+
+    # Save translation values
+    coord.loc[translated_index, 'Crosscor_tx_px'] = tx_bt
+    coord.loc[translated_index, 'Crosscor_ty_px'] = ty_bt
+    coord.loc[after_index, 'Crosscor_tx_px'] = tx_ba
+    coord.loc[after_index, 'Crosscor_ty_px'] = ty_ba
+    coord.loc[translated_index, 'Crosscor_tx_microm'] = tx_bt * px_size
+    coord.loc[translated_index, 'Crosscor_ty_microm'] = ty_bt * px_size
+    coord.loc[after_index, 'Crosscor_tx_microm'] = tx_ba * px_size
+    coord.loc[after_index, 'Crosscor_ty_microm'] = ty_ba * px_size
+
+    coord['Direction'] = np.where((coord['X_input_microm'] > 0) &
+                                  (coord['Y_input_microm'] == 0) &
+                                  (coord['Z_input_microm'] == 0), 'X_positive', float("NaN"))
+    coord['Direction'] = np.where((coord['X_input_microm'] < 0) &
+                                  (coord['Y_input_microm'] == 0) &
+                                  (coord['Z_input_microm'] == 0), 'X_negative', coord['Direction'])
+    coord['Direction'] = np.where((coord['X_input_microm'] == 0) &
+                                  (coord['Y_input_microm'] > 0) &
+                                  (coord['Z_input_microm'] == 0), 'Y_positive', coord['Direction'])
+    coord['Direction'] = np.where((coord['X_input_microm'] == 0) &
+                                  (coord['Y_input_microm'] < 0) &
+                                  (coord['Z_input_microm'] == 0), 'Y_negative', coord['Direction'])
+    coord['Direction'] = np.where((coord['X_input_microm'] == 0) &
+                                  (coord['Y_input_microm'] == 0) &
+                                  (coord['Z_input_microm'] > 0), 'Z_positive', coord['Direction'])
+    coord['Direction'] = np.where((coord['X_input_microm'] == 0) &
+                                  (coord['Y_input_microm'] == 0) &
+                                  (coord['Z_input_microm'] < 0), 'Z_negative', coord['Direction'])
+    coord['Direction'] = np.where((coord['X_input_microm'] == 0) &
+                                  (coord['Y_input_microm'] == 0) &
+                                  (coord['Z_input_microm'] == 0), 'Zero', coord['Direction'])
+
+    coord['theoretical_distance'] = (coord['X_input_microm']
+                                     + coord['Y_input_microm']
+                                     + coord['Z_input_microm'])
+    coord = coord.astype({'theoretical_distance': 'float'})
+
+    # plot
+    fig = plt.figure(figsize=(10, 5))
+    fig.suptitle(f"Cross correlation Alignment of images {coord.ID.values[before_index]}, "
+                 f"{coord.ID.values[translated_index]} "
+                 f"and {coord.ID.values[after_index]}",
+                 fontsize=16)
+    plt.figtext(0.5, 0.85,
+                f"Known offset in µm (y, x): ({int(coord.Y_input_microm.values[translated_index])}; "
+                f"{int(coord.X_input_microm.values[translated_index])})",
+                horizontalalignment='center',
+                fontsize=12)
+    plt.figtext(0.15, 0.15,
+                f"Detected translation in pixels (y, x): ({round(coord.Crosscor_ty_px.values[translated_index], 2)}; "
+                f"{round(coord.Crosscor_tx_px.values[translated_index], 2)})",
+                horizontalalignment='left',
+                fontsize=12)
+    plt.figtext(0.15, 0.1,
+                f"Detected translation in µm (y, x): ({round(coord.Crosscor_ty_microm.values[translated_index], 2)}; "
+                f"{round(coord.Crosscor_tx_microm.values[translated_index], 2)})",
+                horizontalalignment='left',
+                fontsize=12)
+    plt.figtext(0.15, 0.05,
+                f"Detected zero offset in pixels (y, x): ({round(coord.Crosscor_ty_px[after_index], 2)}; "
+                f"{round(coord.Crosscor_tx_px[after_index], 2)})",
+                horizontalalignment='left',
+                fontsize=12)
+    ax1 = plt.subplot(1, 3, 1)
+    ax2 = plt.subplot(1, 3, 2, sharex=ax1, sharey=ax1)
+    ax3 = plt.subplot(1, 3, 3, sharex=ax1, sharey=ax1)
+
+    ax1.imshow(before_image, cmap='inferno')
+    ax1.set_axis_off()
+    ax1.set_title('Reference image')
+    ax2.imshow(transformed_img_bt, cmap='inferno')
+    ax2.patch.set_linewidth(1)
+    ax2.set_axis_off()
+    ax2.set_title('Translation')
+    ax3.imshow(transformed_img_ba, cmap='inferno')
+    ax3.set_axis_off()
+    ax3.set_title("Return to 0")
+    plt.close()
+    # return the translation coordinates and plots
+    return coord, fig

--- a/code/Sort_and_align_skimage_cross_correlation.py
+++ b/code/Sort_and_align_skimage_cross_correlation.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Feb 21 09:41:37 2024
+@author: estel
+"""
+
+# Import basic necessary packages/functions
+import os
+from os.path import dirname
+import pandas as pd
+import numpy as np
+from tkinter import Tk
+from tkinter.filedialog import askdirectory  # User input interface
+
+# Import relevant functions from other scripts
+from Registration_cross_correlation import cross_correlation_xy
+
+# Fixed variables
+px_size = 1/0.512
+plot_nbr = 0
+
+# Get main path
+outer_dir = dirname(os.getcwd())
+# Ask user the path to Z projected data
+root = Tk()
+root.attributes("-topmost", True)
+root.withdraw()
+img_path = askdirectory(initialdir=outer_dir,
+                        title='Select folder containing projected files')
+# Create an output directory if it doesn't exist
+output_path = dirname(img_path) + "/Align_cross_corr"
+os.makedirs(output_path, exist_ok=True)
+
+coord = pd.read_csv(img_path + "/Theoretical_coordinates_table.csv",
+                    encoding='utf-8-sig')
+np.vstack([coord.columns, coord.values])
+# X and Y analysis
+for index, row in coord.iterrows():
+    if (row['X_input_steps'] != 0) & (row['Y_input_steps'] == 0) & (row['Z_input_steps'] == 0):
+        translated_index = int(index)
+        # Add comparison ID number and define plot output name
+        plot_nbr += 1
+        plot_id = str(plot_nbr).zfill(3)
+        plot_path = (f"{output_path}/{plot_id}_Registration_y{int(coord.Y_input_microm.values[translated_index])}"
+                     f"_x{int(coord.X_input_microm.values[translated_index])}_cross_corr.png")
+
+        # Compute a rigid transformation (without depth, only scale + rotation + translation)
+        coord, full_plot = cross_correlation_xy(translated_index, coord, px_size=px_size)
+        full_plot.savefig(plot_path)
+
+    if (row['X_input_steps'] == 0) & (row['Y_input_steps'] != 0) & (row['Z_input_steps'] == 0):
+        translated_index = int(index)
+        # Add comparison ID number and define plot output name
+        plot_nbr += 1
+        plot_id = str(plot_nbr).zfill(3)
+        plot_path = (f"{output_path}/{plot_id}_Registration_y{int(coord.Y_input_microm.values[translated_index])}"
+                     f"_x{int(coord.X_input_microm.values[translated_index])}_cross_corr.png")
+
+        # Compute a rigid transformation (without depth, only scale + rotation + translation)
+        coord, full_plot = cross_correlation_xy(translated_index, coord, px_size=px_size)
+        full_plot.savefig(plot_path)
+
+coord.to_csv(output_path + "/Coord_table_cv2_cross_correlation.csv", index=False)

--- a/code/Z_proj_functions.py
+++ b/code/Z_proj_functions.py
@@ -1,0 +1,92 @@
+# Set of functions used with "Z_projection_and_contrast_enhancement.py"
+
+# Import basic necessary packages/functions
+import os
+import glob
+import numpy as np
+import pandas as pd
+
+# Import the scikit-image package https://scikit-image.org/
+# which allows loading stacks into numpy 3D arrays
+import skimage as ski
+
+
+# Function creating a Z projection across slices (2 to im_size)
+# Input image as numpy array, returns new array
+def z_proj_average(image):
+    image = image[1:, :, :]  # Removes first slice as it often present recording issues such as empty pixel lines
+    im_height = image.shape[1]
+    im_width = image.shape[2]
+    values = []
+    for i in range(im_height):
+        for j in range(im_width):
+            values.append((np.mean(image[:, i, j])))
+
+    values = np.array([values])
+    values = values.reshape(im_height, im_width)
+    return values
+
+
+# Function enhancing contrast by stretching intensity values across the entire range + normalising intensity
+# Input image name, output high contrast image
+def stretch_intensity(image):
+    # Stretch the range of pixel intensity across the 16bits range from 2nd to 98th percentile
+    minval = np.percentile(image, 2)
+    maxval = np.percentile(image, 98)
+    image = np.clip(image, minval, maxval)
+    image = ((image - minval) / (maxval - minval)) * 65535
+    # Check min and max after transformation
+    # print('Min: %.3f, Max: %.3f' % (image.min(), image.max()))
+    # Normalise pixel values between 0 and 1 on a 16bits image
+    image /= 65535
+    # Convert back to a 16bits image
+    image = ski.util.img_as_uint(image)
+    return image
+
+
+# Function extracting all theoretical coordinates information from filename
+# Input the path of Z projected files, saves  a csv table containing file path, image ID, X, Y and Z value
+def theoretical_coordinates_table(z_proj_path):
+    # Find all .tiff in the selected directory
+    path = z_proj_path + '/*.tiff'
+    img_list = glob.glob(path, recursive=False)
+    # Create lists to store image ID and theoretical coordinates
+    id_list = []
+    name_list = []
+    x_list = []
+    y_list = []
+    z_list = []
+    for i in range(0, len(img_list)):
+        file_path = img_list[i]
+        # Get relevant information in file name (i.e X,Y,Z and image ID)
+        image_name = os.path.splitext(os.path.basename(file_path))[0]
+        image_id = int(image_name.split('_')[1])
+        x = int(image_name.split('_')[2].replace("x", ""))
+        y = int(image_name.split('_')[3].replace("y", ""))
+        z = int(image_name.split('_')[4].replace("z", ""))
+
+        id_list.append(image_id)
+        name_list.append(image_name)
+        x_list.append(x)
+        y_list.append(y)
+        z_list.append(z)
+
+    # Merge lists into a dataframe
+    coord_table = pd.DataFrame()
+    coord_table['Image_path'] = img_list
+    coord_table['Image_name'] = name_list
+    coord_table['ID'] = id_list
+    coord_table['X_input_steps'] = x_list
+    coord_table['Y_input_steps'] = y_list
+    coord_table['Z_input_steps'] = z_list
+    coord_table['X_input_microm'] = coord_table['X_input_steps'] / 2
+    coord_table['Y_input_microm'] = coord_table['Y_input_steps'] / 2
+    coord_table['Z_input_microm'] = coord_table['Z_input_steps'] / 2
+
+    print(f'Coordinates table saved as csv : {z_proj_path}/Theoretical_coordinates_table.csv')
+    coord_table.to_csv(path_or_buf=z_proj_path + '/Theoretical_coordinates_table.csv',
+                       sep=',',
+                       na_rep='NA',
+                       header=True,
+                       index=False,
+                       encoding='utf-8-sig')

--- a/code/Z_projection_and_contrast_enhancement.py
+++ b/code/Z_projection_and_contrast_enhancement.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jan 31 14:12:37 2024
+@author: estel
+
+Simple script used to average all the slices in the original .tiff files and tweak pixel intensity
+to improve image quality.
+--> INPUT = raw .tiff stacks
+--> OUTPUT1 = flattened image average as a .tiff in a sub-folder in the same directory as the input files
+--> OUTPUT2 = .csv table containing file path, image ID, X, Y and Z value for each image
+"""
+
+# Import basic necessary packages/functions
+import os
+from os.path import dirname
+import glob
+import numpy as np
+
+# Import the scikit-image package https://scikit-image.org/
+# which allows loading stacks into numpy 3D arrays
+import skimage as ski
+#  Import tkinter for user input interface
+from tkinter import Tk
+from tkinter.filedialog import askdirectory  # User input interface
+
+# Import relevant functions from other scripts
+from Z_proj_functions import z_proj_average
+from Z_proj_functions import stretch_intensity
+from Z_proj_functions import theoretical_coordinates_table
+
+# Get main path
+outer_dir = dirname(os.getcwd())
+# Ask user the path to the raw data (stack .tiff files)
+root = Tk()
+root.attributes("-topmost", True)
+root.withdraw()
+stack_path = askdirectory(initialdir=outer_dir, title='Select Folder containing .tiff stacks')
+print(stack_path)
+
+# Create an output directory if it doesn't exist
+output_path = stack_path + "/Z_proj"
+os.makedirs(output_path, exist_ok=True)  # exist_ok set to true to not raise an error if the folder exists
+# Set fixed variables
+slice_nbr = 200
+
+# Find all stack .tiff in the selected directory
+path = stack_path + '/*.tiff'
+stack_files = glob.glob(path, recursive=False)
+nbr_files = len(stack_files)
+
+# Loop through the list of files, apply Z average projection and enhance contrast
+for i in range(0, nbr_files):
+    image_name = os.path.basename(stack_files[i])
+    print(image_name)
+    # Make sure files are numbered properly (i.e. no duplicate ID)
+# THIS DOESN'T WORK IF THE IMAGES ARE NOT IN THE CORRECT ORDER
+# I.E. ALTERNATING ZERO AND TRANSLATION (0,0,0) - (x,0,0) - (0,0,0) ...
+    if i > 1:
+        previous_image_name = os.path.basename(stack_files[i-1])
+        image_id = int(image_name.split('_')[0])
+        previous_id = int(previous_image_name.split('_')[0])
+        if image_id == previous_id:
+            new_id = str(image_id+1).zfill(3)
+            image_name = new_id + image_name[image_name.index('_'):]
+    # Open image and extract stack size
+    im = ski.io.imread(stack_files[i], dtype=np.uint16)
+    # check stack is 200 slices
+    if im.shape[0] == slice_nbr:
+        print('Correct slide number in file %s' % image_name)
+        # Apply Z stack on slices (2 to im_size)
+        im = z_proj_average(im)
+        # Increase contrast
+        im = stretch_intensity(im)
+        # ski.io.imshow(im) (use to show image when testing only
+        # Save as a new .tiff file
+        ski.io.imsave(output_path + "/Flat_" + image_name, im)
+    else:
+        print('Not enough slices in file : %s' % image_name)
+
+# Create a table containing all coordinates for each file
+theoretical_coordinates_table(output_path)


### PR DESCRIPTION
Files should be used as follow : 
- 1. Run  Z_projection_and_contrast_enhancement.py on raw stack.tiff files (calls functions defined in Z_proj_functions.py). This script averages all slices in the stack, and outputs the projected images as .tiff with normalised and stretched intensity to increase contrast, and a .csv table containing each image, path, name, ID, and theoretical displacement values.
This step strongly relies on correct file naming (ID_x_value_y_value_z_value) and file order, and could be modified to allow for user error.

- 2. Run Sort_and_align_skimage_cross_correlation.py on the projected files obtained from 1. (calls functions defined in Registration_cross_correlation.py). This script applies a cross correlation function to align the images, and outputs a summary image for each set of 3 images (initial (0;0), translation (tx,ty), and return to (0;0)) depicting the aligned images, and the estimated displacement compared to the initial (0;0) in µm and pixels. It also saves a .csv table of these values.

![014_Registration_y0_x-120_cross_corr](https://github.com/Open-2-Photon-Microscope/OF-larger-delta-stage/assets/83412687/01e8ba4e-bc53-418b-a9e7-33a321def878)

- 3. Run Cross_correlation_graphs.py to obtain summary plots showing the error in X and Y translation, as well as the error in returning to zero after a known translation.
![X_translation_error](https://github.com/Open-2-Photon-Microscope/OF-larger-delta-stage/assets/83412687/4ca48ade-e93e-4aae-a60b-1be0851f8114)
![Y_translation_error](https://github.com/Open-2-Photon-Microscope/OF-larger-delta-stage/assets/83412687/f3ec1787-578b-4929-8c1d-76812a6ad58d)
![Zero_translation_error](https://github.com/Open-2-Photon-Microscope/OF-larger-delta-stage/assets/83412687/04c72859-14bb-4502-8233-af8642097ce0)

